### PR TITLE
Remove http-exceptions dependency

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -44,7 +44,6 @@ private object AppDependencies {
 
   val compile = Seq(
     "com.typesafe.play" %% "play" % PlayVersion.current % "provided",
-    "uk.gov.hmrc" %% "http-exceptions" % "0.4.0",
     "uk.gov.hmrc" %% "play-auditing" % "0.2.0"
   )
 


### PR DESCRIPTION
http-exceptions is brought in transitively via play-auditing, so
specifying a version directly is causing an eviction warning:

```
[warn] There may be incompatibilities among your library dependencies.
[warn] Here are some of the libraries that were evicted:
[warn]  * uk.gov.hmrc:http-exceptions_2.11:0.4.0 -> 1.0.0 (caller:
uk.gov.hmrc:play-filters_2.11:3.2.0-0-g0000000,
uk.gov.hmrc:play-auditing_2.11:0.2.0, uk.gov.hmrc:http-verbs_2.11:3.0.0)
```
