### PR TITLE
Upgrade to play-auditing 1.8.0

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -44,7 +44,7 @@ private object AppDependencies {
 
   val compile = Seq(
     "com.typesafe.play" %% "play" % PlayVersion.current % "provided",
-    "uk.gov.hmrc" %% "play-auditing" % "1.5.1"
+    "uk.gov.hmrc" %% "play-auditing" % "1.8.0"
   )
 
   trait TestDependencies {


### PR DESCRIPTION
Recent changes to http-verbs and play-auditing require version upgrades to downstream libraries.
