### PR TITLE
TXMNT-366 Refactored out hmrctest

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -60,7 +60,6 @@ private object AppDependencies {
         "org.scalatest" %% "scalatest" % "2.2.4" % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" %  scope,
         "org.scalactic" %% "scalactic" % "2.2.2" % scope,
-        "uk.gov.hmrc" %% "hmrctest" % "2.0.0" % scope,
         "org.pegdown" % "pegdown" % "1.5.0" % scope,
         "org.mockito" % "mockito-all" % "1.9.5" % "test"
       )

--- a/src/test/scala/uk/gov/hmrc/play/filters/frontend/CookieCryptoFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/filters/frontend/CookieCryptoFilterSpec.scala
@@ -30,11 +30,10 @@ import play.api.Logger
 import play.api.mvc._
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.filters.LogCapturing
-import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
 
-class CookieCryptoFilterSpec extends UnitSpec with ScalaFutures with Matchers with LogCapturing with LoneElement with MockitoSugar with TypeCheckedTripleEquals {
+class CookieCryptoFilterSpec extends WordSpecLike with ScalaFutures with Matchers with LogCapturing with LoneElement with MockitoSugar with TypeCheckedTripleEquals {
 
   private trait Setup extends Results {
     implicit val headerEquiv = RequestHeaderEquivalence

--- a/src/test/scala/uk/gov/hmrc/play/filters/frontend/DeviceIdFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/filters/frontend/DeviceIdFilterSpec.scala
@@ -25,20 +25,15 @@ import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mock.MockitoSugar
+import org.scalatestplus.play.OneAppPerSuite
 import play.api.mvc._
-import play.api.test.{FakeApplication, FakeRequest}
+import play.api.test.FakeRequest
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.audit.model.{DataEvent, EventTypes}
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 import scala.concurrent.Future
 
-trait FakePlayApplication extends WithFakeApplication {
-  this: Suite =>
-  override lazy val fakeApplication = FakeApplication()
-}
-
-class DeviceIdFilterSpec extends UnitSpec with WithFakeApplication with ScalaFutures with MockitoSugar with BeforeAndAfterEach with FakePlayApplication with TypeCheckedTripleEquals with Inspectors {
+class DeviceIdFilterSpec extends WordSpecLike with Matchers with OneAppPerSuite with ScalaFutures with MockitoSugar with BeforeAndAfterEach with TypeCheckedTripleEquals with Inspectors {
 
   lazy val timestamp = System.currentTimeMillis()
 


### PR DESCRIPTION
Hmrctest has had a version bump - play-filters uses hmrctest
but only to inherit from the underlying scalatest traits.
This should reduce PR's in the future.