### PR TITLE
Made cookieName lazy to allow compile time DI

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/filters/frontend/CookieCryptoFilter.scala
+++ b/src/main/scala/uk/gov/hmrc/play/filters/frontend/CookieCryptoFilter.scala
@@ -29,7 +29,7 @@ trait CookieCryptoFilter extends Filter {
 
   implicit def mat: Materializer
 
-  protected val cookieName: String = Session.COOKIE_NAME
+  protected lazy val cookieName: String = Session.COOKIE_NAME
   protected val encrypter: (String) => String
   protected val decrypter: (String) => String
 

--- a/src/test/scala/uk/gov/hmrc/play/filters/frontend/CookieCryptoFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/filters/frontend/CookieCryptoFilterSpec.scala
@@ -61,7 +61,7 @@ class CookieCryptoFilterSpec extends WordSpecLike with ScalaFutures with Matcher
       implicit val system = ActorSystem("test")
       implicit val mat: Materializer = ActorMaterializer()
 
-      override val cookieName = Setup.this.cookieName
+      override lazy val cookieName = Setup.this.cookieName
       protected val encrypter = encrypt _
       protected val decrypter = decrypt _
 


### PR DESCRIPTION
Session.COOKIE_NAME depends on running application with the fallback
to "PLAY_SESSION" value if running application is not ready.

We need to make cookieName lazy so it will pick it's value from
configuration of a running application.