### PR TITLE
PE-2795: Do not wipe session in SessionTimeoutFilter if ts field missing

### DIFF
--- a/src/test/scala/uk/gov/hmrc/play/filters/frontend/SessionTimeoutFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/play/filters/frontend/SessionTimeoutFilterSpec.scala
@@ -70,28 +70,48 @@ class SessionTimeoutFilterSpec extends WordSpecLike with Matchers with ScalaFutu
       result.futureValue.session.get("custom") shouldBe Some("custom")
     }
 
-    "update old timestamp" in {
+    "strip only auth token from request if timestamp is missing" in {
+      implicit val rh = exampleRequest.withSession(authToken -> "a-token", "custom" -> "custom")
+
+      filter.apply { req =>
+        req.session.get(authToken) shouldBe None
+        req.session.get("custom") shouldBe Some("custom")
+        Future.successful(Results.Ok)
+      }(rh)
+    }
+
+    "strip auth token from result if timestamp is missing" in {
+      implicit val rh = exampleRequest.withSession(authToken -> "a-token", loginOrigin -> "gg", "custom" -> "custom")
+
+      val result = filter(successfulResult)(rh)
+
+      result.futureValue.session.get(authToken) shouldBe None
+      result.futureValue.session.get(loginOrigin) shouldBe Some("gg")
+      result.futureValue.session.get("custom") shouldBe Some("custom")
+    }
+
+    "update old timestamp with current time" in {
       implicit val rh = exampleRequest.withSession(lastRequestTimestamp -> now.minusDays(1).getMillis.toString)
       val result = filter.apply(successfulResult)(rh)
       result.futureValue.session.get(lastRequestTimestamp) shouldBe Some(now.getMillis.toString)
     }
 
-    "update recent timestamp" in {
+    "update recent timestamp with current time" in {
       implicit val rh = exampleRequest.withSession(lastRequestTimestamp -> now.minusSeconds(1).getMillis.toString)
       val result = filter.apply(successfulResult)(rh)
       result.futureValue.session.get(lastRequestTimestamp) shouldBe Some(now.getMillis.toString)
     }
 
-    "update an invalid timestamp with correct one" in {
+    "ignore an invalid timestamp" in {
       implicit val rh = exampleRequest.withSession(lastRequestTimestamp -> "invalid-format")
       val result = filter.apply(successfulResult)(rh)
-      result.futureValue.session.get(lastRequestTimestamp) shouldBe Some(now.getMillis.toString)
+      result.futureValue.session.get(lastRequestTimestamp) shouldBe Some("invalid-format")
     }
 
-    "add timestamp if missing" in {
+    "do not add timestamp if it is missing" in {
       implicit val rh = exampleRequest.withSession()
       val result = filter.apply(successfulResult)(rh)
-      result.futureValue.session.get(lastRequestTimestamp) shouldBe Some(now.getMillis.toString)
+      result.futureValue.session.get(lastRequestTimestamp) shouldBe None
     }
 
   }


### PR DESCRIPTION
Some login flows that did not contain a valid auth session use the session cookie to set state. The previous implementation of the SessionTimeoutFilter wiped out these values if the `ts` field was not present. This broke those flows.