### PR TITLE
GG-1966 - Make the mdtpdi cookie secure

### DIFF
--- a/src/main/scala/uk/gov/hmrc/play/filters/frontend/DeviceIdCookie.scala
+++ b/src/main/scala/uk/gov/hmrc/play/filters/frontend/DeviceIdCookie.scala
@@ -38,5 +38,5 @@ trait DeviceIdCookie {
     makeCookie(deviceId)
   }
 
-  def makeCookie(deviceId: DeviceId) = Cookie(DeviceId.MdtpDeviceId, deviceId.value, Some(DeviceId.TenYears))
+  def makeCookie(deviceId: DeviceId) = Cookie(DeviceId.MdtpDeviceId, deviceId.value, Some(DeviceId.TenYears), secure = true)
 }


### PR DESCRIPTION
We would like to make the `mdtpdi` cookie secure. 

This change adds the `mdtpdi` cookie to the `Set-Cookie` response header on every request. This is to ensure existing `mdtpdi` cookies without the secure flag are updated to be secure. We are unable to conditionally do this only for insecure cookies as the secure flag is not sent client -> server in the `Cookie` request header. 

CCing @benwheeler